### PR TITLE
Take the tokio runtime by reference

### DIFF
--- a/examples/decompress_s3.rs
+++ b/examples/decompress_s3.rs
@@ -85,7 +85,7 @@ fn main() {
         let rt = tokio::runtime::Runtime::new().unwrap();
 
         // We get a wrapper over S3 object that does knows how to do seeking of a file. Note however that this is just the raw data!
-        let seekable_raw_object = s3.get_seekable_object(rt, req).unwrap();
+        let seekable_raw_object = s3.get_seekable_object(&rt, req).unwrap();
 
         // We wrap the seekable S3 object with a shim that actually knows about the
         // compression.

--- a/examples/roundtrip_stream_s3.rs
+++ b/examples/roundtrip_stream_s3.rs
@@ -243,7 +243,7 @@ async fn main() {
             ..Default::default()
         };
         // We get a wrapper over S3 object that does knows how to do seeking of a file. Note however that this is just the raw data!
-        let seekable_raw_object = s3.get_seekable_object(runtime, req).unwrap();
+        let seekable_raw_object = s3.get_seekable_object(&runtime, req).unwrap();
         // We wrap the seekable S3 object with a shim that actually knows about the
         // compression.
         let mut seekable_uncompressed_object =


### PR DESCRIPTION
There's no need for every SeekableS3Object to own its own tokio runtime -
they can share perfectly well.